### PR TITLE
Refactor/api auth cleanup

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -70,7 +70,7 @@ fastify.register(rateLimit, {
 
 // Auth Hook
 fastify.addHook('preHandler', async (request, reply) => {
-  const publicRoutes = ['/auth/github', '/health', '/webhooks/github'];
+  const publicRoutes = ['/auth/github', '/health', '/webhooks/github', '/auth/logout'];
   // WebSocket routes handle auth via query parameter, not header
   const isWsLogStream = request.url.includes('/logs/stream');
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -218,12 +218,6 @@ fastify.post('/auth/logout', async (request, reply) => {
  * Input Validation: None required for global repo list.
  */
 fastify.get('/github/repos', async (request, reply) => {
-  try {
-    await request.jwtVerify();
-  } catch {
-    return reply.status(401).send({ error: 'Unauthorized' });
-  }
-
   const ghToken = request.cookies.gh_token;
   if (!ghToken) return reply.status(401).send({ error: 'GitHub token missing' });
 
@@ -272,12 +266,6 @@ fastify.get('/github/repos', async (request, reply) => {
  * Input Validation: Sanitizes owner and repo to prevent path traversal.
  */
 fastify.get('/github/repos/:owner/:repo/branches', async (request, reply) => {
-  try {
-    await request.jwtVerify();
-  } catch {
-    return reply.status(401).send({ error: 'Unauthorized' });
-  }
-
   const ghToken = request.cookies.gh_token;
   if (!ghToken) return reply.status(401).send({ error: 'GitHub token missing' });
 


### PR DESCRIPTION
This pull request updates the authentication logic for certain GitHub-related API routes and adds the `/auth/logout` endpoint to the list of public routes. The main changes focus on simplifying access control for repository and branch listing endpoints, relying solely on the presence of a GitHub token in cookies rather than JWT verification.

**Authentication logic updates:**

* Removed JWT verification from the `/github/repos` endpoint; now only checks for the presence of a `gh_token` cookie for authentication.
* Removed JWT verification from the `/github/repos/:owner/:repo/branches` endpoint; now only checks for the presence of a `gh_token` cookie for authentication.

**Public route configuration:**

* Added `/auth/logout` to the list of public routes in the authentication hook, allowing unauthenticated access to this endpoint.