### PR TITLE
fix(api,worker): ensure env vars are loaded before other imports to f…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,7 @@
-import dotenv from 'dotenv';
-import path from 'path';
-
-// Load environment variables as early as possible
-dotenv.config({ path: path.resolve(__dirname, '../../../.env'), override: true });
+import { env, initEnv } from './config/env';
+import './load-env';
 
 // Validate environment variables before doing anything else
-import { env, initEnv } from './config/env';
 initEnv();
 
 import { STATUS_RECONCILIATION_INTERVAL_MS } from './config/constants';

--- a/apps/api/src/load-env.ts
+++ b/apps/api/src/load-env.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../../.env'), override: true });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,8 +1,4 @@
-import dotenv from 'dotenv';
-import path from 'path';
-
-// Load environment variables as early as possible
-dotenv.config({ path: path.resolve(__dirname, '../../../.env'), override: true });
+import './load-env';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fastifyCookie from '@fastify/cookie';

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,9 +1,5 @@
-import dotenv from 'dotenv';
-import path from 'path';
 import 'reflect-metadata';
-
-// Load environment variables as early as possible
-dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+import './load-env';
 
 // Validate environment variables before doing anything else
 import { initEnv } from './config/env';

--- a/apps/worker/src/load-env.ts
+++ b/apps/worker/src/load-env.ts
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Load environment variables from the root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../../.env'), override: true });


### PR DESCRIPTION
…ix ENCRYPTION_SALT warning

This pull request refactors how environment variables are loaded across the API and worker services. The main change is centralizing the dotenv configuration into a dedicated `load-env.ts` file for both services, improving maintainability and consistency. Direct dotenv imports and configuration calls have been removed from entry points and replaced with imports of the new loader module.

**Environment variable loading refactor:**

* Created `load-env.ts` in both `apps/api/src` and `apps/worker/src` to centralize dotenv setup, ensuring environment variables are loaded from the root `.env` file with the correct path and override behavior.
* Updated `index.ts` and `server.ts` in `apps/api/src` and `index.ts` in `apps/worker/src` to import the new `load-env.ts` module instead of configuring dotenv directly, removing redundant dotenv and path imports. [[1]](diffhunk://#diff-55a96a3cad00af7af702aeea23e5691e713c4898618aaa8de6eb97c32c851538L1-L8) [[2]](diffhunk://#diff-3504cff00dc0b301e00da4235ed65736b5fd11064dd71e70f2cca2e4f00f77ebL1-R1) [[3]](diffhunk://#diff-35a8cc86d7227c6dfab05caf2fc2a13d72880ca8b6abfdeaa7ce49e3cd1c2f2aL1-R2)