### PR TITLE
fix(worker): handle missing deployment records and add clear-queue script

### DIFF
--- a/scripts/clear-queue.js
+++ b/scripts/clear-queue.js
@@ -1,0 +1,22 @@
+const { Queue } = require('bullmq');
+const IORedis = require('ioredis');
+
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const connection = new IORedis(redisUrl, { maxRetriesPerRequest: null });
+
+async function clearQueue() {
+  const queue = new Queue('deployments', { connection });
+  console.log('Clearing "deployments" queue...');
+  await queue.drain();
+  await queue.clean(0, 1000, 'completed');
+  await queue.clean(0, 1000, 'failed');
+  await queue.clean(0, 1000, 'wait');
+  await queue.clean(0, 1000, 'active');
+  console.log('Queue cleared.');
+  await connection.quit();
+}
+
+clearQueue().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request improves the reliability of deployment processing in the worker service and introduces a new utility script for queue management. The main changes include adding database checks before starting deployments, handling specific database errors more gracefully, and providing a script to clear the deployment queue.

**Worker reliability and error handling:**

* Added a check in `worker.ts` to verify that a deployment exists in the database before starting the deployment process, logging and skipping the job if not found.
* Improved error handling in `worker.ts` by specifically catching and logging when a deployment record is deleted during processing (Prisma error code `P2025`), providing clearer diagnostics.

**Queue management utility:**

* Added a new script `scripts/clear-queue.js` to clear the BullMQ 'deployments' queue, including draining and cleaning jobs in various states, to assist with local development and troubleshooting.